### PR TITLE
Make package name consistent

### DIFF
--- a/diskqueue.go
+++ b/diskqueue.go
@@ -1,4 +1,4 @@
-package diskQueue
+package diskqueue
 
 // copied from github.com/nsqio/go-diskqueue, need change log module
 


### PR DESCRIPTION
go mod disallows different package names under the same directory.